### PR TITLE
[MOD/#205] 등록화면 다음버튼 과 imePadding을 수정합니다.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Spoony Android
-* @SOPT-all/35-APPJAM-ANDROID-SPOONY
+* @spooooony/android-spoony

--- a/app/src/main/java/com/spoony/spoony/presentation/register/RegisterStepTwoScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/register/RegisterStepTwoScreen.kt
@@ -98,11 +98,8 @@ fun RegisterStepTwoScreen(
             onPhotosSelected = viewModel::updatePhotos
         )
 
-        Spacer(
-            modifier = Modifier
-                .weight(1f)
-                .defaultMinSize(24.dp)
-        )
+        Spacer(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.height(24.dp))
 
         NextButton(
             enabled = isNextButtonEnabled,

--- a/app/src/main/java/com/spoony/spoony/presentation/register/RegisterStepTwoScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/register/RegisterStepTwoScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding

--- a/app/src/main/java/com/spoony/spoony/presentation/register/RegisterStepTwoScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/register/RegisterStepTwoScreen.kt
@@ -38,6 +38,7 @@ import com.spoony.spoony.core.designsystem.component.textfield.SpoonyLineTextFie
 import com.spoony.spoony.core.designsystem.theme.SpoonyAndroidTheme
 import com.spoony.spoony.core.designsystem.type.ButtonStyle
 import com.spoony.spoony.core.util.extension.addFocusCleaner
+import com.spoony.spoony.core.util.extension.advancedImePadding
 import com.spoony.spoony.presentation.register.RegisterViewModel.Companion.MAX_DETAIL_REVIEW_LENGTH
 import com.spoony.spoony.presentation.register.RegisterViewModel.Companion.MAX_ONE_LINE_REVIEW_LENGTH
 import com.spoony.spoony.presentation.register.RegisterViewModel.Companion.MIN_DETAIL_REVIEW_LENGTH
@@ -72,6 +73,7 @@ fun RegisterStepTwoScreen(
         modifier = modifier
             .fillMaxSize()
             .addFocusCleaner(focusManager)
+            .advancedImePadding()
             .verticalScroll(rememberScrollState())
             .padding(top = 22.dp, bottom = 17.dp, start = 20.dp, end = 20.dp)
     ) {

--- a/app/src/main/java/com/spoony/spoony/presentation/register/component/SearchResultItem.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/register/component/SearchResultItem.kt
@@ -47,7 +47,9 @@ fun SearchResultItem(
         Row(
             verticalAlignment = Alignment.Top,
             horizontalArrangement = Arrangement.Start,
-            modifier = Modifier.padding(vertical = 10.dp)
+            modifier = Modifier
+                .padding(vertical = 10.dp)
+                .weight(1f)
         ) {
             Icon(
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_pin_24),


### PR DESCRIPTION
## Related issue 🛠
- closed #205

## Work Description ✏️
- Nextbutton 패딩 수정
- ImePadding 추가
- 검색 결과 도로명 주소가 길어지면 X아이콘 사라지는 버그 수정

## Screenshot 📸
https://github.com/user-attachments/assets/fbafcfd7-e0be-4e3e-b2fd-5728474a0562

### Before
![image](https://github.com/user-attachments/assets/74f94e30-4e39-4cbd-884f-f587c3c82b38)

### After
![image](https://github.com/user-attachments/assets/7414c206-da4b-435f-9920-5843df8b22b0)

## To Reviewers 📢
- 갤럭시 A8에서 테스트 하다가 발견한 패딩 이슈와 놓친 imePadding 적용했습니다. 그리고 X버튼이 사라져서 버그인줄 알았는데 밀리더라구요.... 요것도 같이 수정했습니다. 하는김에 코드오너도 넣어봤어요~