### PR TITLE
[FIX/#216] 등록 뷰의 툴팁 상태를 DataStore로 저장합니다.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
     implementation(libs.bundles.androidx)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.kotlinx.immutable)
+    implementation(libs.androidx.datastore.preferences)
 
     // Network
     implementation(platform(libs.okhttp.bom))

--- a/app/src/main/java/com/spoony/spoony/data/datasource/TooltipPreferencesDataSource.kt
+++ b/app/src/main/java/com/spoony/spoony/data/datasource/TooltipPreferencesDataSource.kt
@@ -1,0 +1,24 @@
+package com.spoony.spoony.data.datasource
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class TooltipPreferencesDataSource(private val dataStore: DataStore<Preferences>) {
+
+    val isTooltipShown: Flow<Boolean> = dataStore.data
+        .map { preferences -> preferences[SHOW_REGISTER_TOOLTIP] ?: true }
+
+    suspend fun setTooltipShown(shown: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[SHOW_REGISTER_TOOLTIP] = shown
+        }
+    }
+
+    companion object {
+        private val SHOW_REGISTER_TOOLTIP = booleanPreferencesKey("show_register_tooltip")
+    }
+}

--- a/app/src/main/java/com/spoony/spoony/data/di/TooltipPreferencesModule.kt
+++ b/app/src/main/java/com/spoony/spoony/data/di/TooltipPreferencesModule.kt
@@ -1,0 +1,33 @@
+package com.spoony.spoony.data.di
+
+import android.content.Context
+import androidx.datastore.preferences.preferencesDataStore
+import com.spoony.spoony.data.datasource.TooltipPreferencesDataSource
+import com.spoony.spoony.data.repositoryimpl.TooltipPreferencesRepositoryImpl
+import com.spoony.spoony.domain.repository.TooltipPreferencesRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+val Context.dataStore by preferencesDataStore(name = "tooltip_preferences")
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TooltipPreferencesModule {
+
+    @Provides
+    @Singleton
+    fun provideTooltipPreferencesDataSource(
+        @ApplicationContext context: Context
+    ): TooltipPreferencesDataSource =
+        TooltipPreferencesDataSource(context.dataStore)
+
+    @Provides
+    @Singleton
+    fun provideTooltipPreferencesRepository(
+        dataSource: TooltipPreferencesDataSource
+    ): TooltipPreferencesRepository = TooltipPreferencesRepositoryImpl(dataSource)
+}

--- a/app/src/main/java/com/spoony/spoony/data/repositoryimpl/TooltipPreferencesRepositoryImpl.kt
+++ b/app/src/main/java/com/spoony/spoony/data/repositoryimpl/TooltipPreferencesRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.spoony.spoony.data.repositoryimpl
+
+import com.spoony.spoony.data.datasource.TooltipPreferencesDataSource
+import com.spoony.spoony.domain.repository.TooltipPreferencesRepository
+import kotlinx.coroutines.flow.Flow
+
+class TooltipPreferencesRepositoryImpl(
+    private val dataSource: TooltipPreferencesDataSource
+) : TooltipPreferencesRepository {
+    override fun isTooltipShown(): Flow<Boolean> = dataSource.isTooltipShown
+
+    override suspend fun setTooltipShown(shown: Boolean) {
+        dataSource.setTooltipShown(shown)
+    }
+}

--- a/app/src/main/java/com/spoony/spoony/domain/repository/TooltipPreferencesRepository.kt
+++ b/app/src/main/java/com/spoony/spoony/domain/repository/TooltipPreferencesRepository.kt
@@ -1,0 +1,8 @@
+package com.spoony.spoony.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface TooltipPreferencesRepository {
+    fun isTooltipShown(): Flow<Boolean>
+    suspend fun setTooltipShown(shown: Boolean)
+}

--- a/app/src/main/java/com/spoony/spoony/presentation/register/RegisterScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/register/RegisterScreen.kt
@@ -41,6 +41,7 @@ fun RegisterScreen(
     navigateToExplore: () -> Unit,
     viewModel: RegisterViewModel = hiltViewModel()
 ) {
+    val tooltipShown by viewModel.tooltipShownFlow.collectAsStateWithLifecycle(initialValue = false)
     val state by viewModel.state.collectAsStateWithLifecycle()
     val navController = rememberNavController()
     val showSnackBar = LocalSnackBarTrigger.current
@@ -86,7 +87,7 @@ fun RegisterScreen(
         }
 
         AnimatedVisibility(
-            visible = state.showRegisterSnackBar,
+            visible = tooltipShown,
             enter = fadeIn() + slideInVertically(initialOffsetY = { -it }),
             exit = fadeOut() + slideOutVertically(targetOffsetY = { it }),
             modifier = Modifier

--- a/app/src/main/java/com/spoony/spoony/presentation/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/register/RegisterViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.spoony.spoony.domain.entity.CategoryEntity
 import com.spoony.spoony.domain.entity.PlaceEntity
 import com.spoony.spoony.domain.repository.RegisterRepository
+import com.spoony.spoony.domain.repository.TooltipPreferencesRepository
 import com.spoony.spoony.presentation.register.component.SelectedPhoto
 import com.spoony.spoony.presentation.register.model.Category
 import com.spoony.spoony.presentation.register.model.Place
@@ -12,6 +13,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -23,8 +25,11 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class RegisterViewModel @Inject constructor(
-    private val repository: RegisterRepository
+    private val repository: RegisterRepository,
+    private val tooltipPreferencesRepository: TooltipPreferencesRepository
 ) : ViewModel() {
+
+    val tooltipShownFlow: Flow<Boolean> = tooltipPreferencesRepository.isTooltipShown()
 
     private val _state = MutableStateFlow(RegisterState())
     val state: StateFlow<RegisterState>
@@ -230,7 +235,9 @@ class RegisterViewModel @Inject constructor(
     }
 
     fun hideRegisterSnackBar() {
-        _state.update { it.copy(showRegisterSnackBar = false) }
+        viewModelScope.launch {
+            tooltipPreferencesRepository.setTooltipShown(false)
+        }
     }
 
     companion object {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 compileSdk = "35"
+datastorePreferences = "1.1.3"
 minSdk = "28"
 targetSdk = "35"
 jvmTarget = "11"
@@ -71,6 +72,7 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 
 # Androidx
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-core-splachscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplachscreen" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }


### PR DESCRIPTION
## Related issue 🛠
- closed #216 

## Work Description ✏️
- DataStore 의존성 추가
- 상태 저장 로직 변경

## Screenshot 📸

https://github.com/user-attachments/assets/9f211473-6d52-4d64-ad97-a193532a36e0


## To Reviewers 📢
데이터 삭제 or 앱 삭제 시에만 툴팁이 표시됩니다~