### PR TITLE
[MOD/#234] Typography 수정 및 이미지 프리뷰 추가

### DIFF
--- a/app/src/main/java/com/spoony/spoony/core/designsystem/component/image/SpoonyImage.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/component/image/SpoonyImage.kt
@@ -1,14 +1,19 @@
 package com.spoony.spoony.core.designsystem.component.image
 
+import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.vectorResource
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.spoony.spoony.R
 
 @Composable
 fun UrlImage(
@@ -18,14 +23,23 @@ fun UrlImage(
     contentScale: ContentScale = ContentScale.Crop,
     contentDescription: String? = null
 ) {
-    AsyncImage(
-        model = ImageRequest.Builder(LocalContext.current)
-            .data(imageUrl)
-            .crossfade(true)
-            .build(),
-        contentDescription = contentDescription,
-        contentScale = contentScale,
-        modifier = modifier
-            .clip(shape)
-    )
+    if (LocalInspectionMode.current) {
+        Image(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_spoony_launcher_background),
+            contentDescription = contentDescription,
+            contentScale = contentScale,
+            modifier = modifier.clip(shape)
+
+        )
+    } else {
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(imageUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = contentDescription,
+            contentScale = contentScale,
+            modifier = modifier.clip(shape)
+        )
+    }
 }

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/component/topappbar/CloseTopAppBar.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/component/topappbar/CloseTopAppBar.kt
@@ -37,7 +37,7 @@ fun CloseTopAppBar(
     ) {
         Text(
             text = title,
-            style = SpoonyAndroidTheme.typography.title2b,
+            style = SpoonyAndroidTheme.typography.title3b,
             color = SpoonyAndroidTheme.colors.black,
             modifier = Modifier
                 .padding(start = 20.dp)

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/component/topappbar/TitleTopAppBar.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/component/topappbar/TitleTopAppBar.kt
@@ -30,7 +30,7 @@ fun TitleTopAppBar(
         content = {
             Text(
                 text = title,
-                style = SpoonyAndroidTheme.typography.title2b,
+                style = SpoonyAndroidTheme.typography.title3b,
                 color = SpoonyAndroidTheme.colors.black,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/theme/Color.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/theme/Color.kt
@@ -311,7 +311,7 @@ fun SpoonyMainColorsPreview() {
         Column {
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.main0,
                 modifier = Modifier.background(
                     color = SpoonyAndroidTheme.colors.black
@@ -319,7 +319,7 @@ fun SpoonyMainColorsPreview() {
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.main100,
                 modifier = Modifier.background(
                     color = SpoonyAndroidTheme.colors.black
@@ -327,42 +327,42 @@ fun SpoonyMainColorsPreview() {
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.main200
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.main300
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.main400
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.main500
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.main600
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.main700
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.main800
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.main900
             )
         }
@@ -376,12 +376,12 @@ fun SpoonyPointColorsPreview() {
         Column {
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.orange400
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.orange100,
                 modifier = Modifier.background(
                     color = SpoonyAndroidTheme.colors.black
@@ -389,12 +389,12 @@ fun SpoonyPointColorsPreview() {
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.pink400
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.pink100,
                 modifier = Modifier.background(
                     color = SpoonyAndroidTheme.colors.black
@@ -402,12 +402,12 @@ fun SpoonyPointColorsPreview() {
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.green400
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.green100,
                 modifier = Modifier.background(
                     color = SpoonyAndroidTheme.colors.black
@@ -415,12 +415,12 @@ fun SpoonyPointColorsPreview() {
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.blue400
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.blue100,
                 modifier = Modifier.background(
                     color = SpoonyAndroidTheme.colors.black
@@ -428,12 +428,12 @@ fun SpoonyPointColorsPreview() {
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.purple400
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.purple100,
                 modifier = Modifier.background(
                     color = SpoonyAndroidTheme.colors.black
@@ -441,7 +441,7 @@ fun SpoonyPointColorsPreview() {
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.error400
             )
         }
@@ -455,7 +455,7 @@ fun SpoonyStateColorsPreview() {
         Column {
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.error400
             )
         }
@@ -469,7 +469,7 @@ fun SpoonyGrayScaleColorsPreview() {
         Column {
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.white,
                 modifier = Modifier.background(
                     color = SpoonyAndroidTheme.colors.black
@@ -477,12 +477,12 @@ fun SpoonyGrayScaleColorsPreview() {
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.black
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.gray0,
                 modifier = Modifier.background(
                     color = SpoonyAndroidTheme.colors.black
@@ -490,7 +490,7 @@ fun SpoonyGrayScaleColorsPreview() {
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.gray100,
                 modifier = Modifier.background(
                     color = SpoonyAndroidTheme.colors.black
@@ -498,42 +498,42 @@ fun SpoonyGrayScaleColorsPreview() {
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.gray200
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.gray300
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.gray400
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.gray500
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.gray600
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.gray700
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.gray800
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.gray900
             )
         }

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/theme/Type.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/theme/Type.kt
@@ -25,8 +25,9 @@ val PretendardMedium = FontFamily(Font(R.font.pretendard_medium, FontWeight.Medi
 @Stable
 class SpoonyTypography(
     title1: TextStyle,
-    title2b: TextStyle,
-    title2sb: TextStyle,
+    title2: TextStyle,
+    title3b: TextStyle,
+    title3sb: TextStyle,
     body1b: TextStyle,
     body1sb: TextStyle,
     body1m: TextStyle,
@@ -41,9 +42,11 @@ class SpoonyTypography(
 
     var title1 by mutableStateOf(title1)
         private set
-    var title2b by mutableStateOf(title2b)
+    var title2 by mutableStateOf(title2)
         private set
-    var title2sb by mutableStateOf(title2sb)
+    var title3b by mutableStateOf(title3b)
+        private set
+    var title3sb by mutableStateOf(title3sb)
         private set
     var body1b by mutableStateOf(body1b)
         private set
@@ -68,8 +71,9 @@ class SpoonyTypography(
 
     fun copy(
         title1: TextStyle = this.title1,
-        title2b: TextStyle = this.title2b,
-        title2sb: TextStyle = this.title2sb,
+        title2: TextStyle = this.title2,
+        title3b: TextStyle = this.title3b,
+        title3sb: TextStyle = this.title3sb,
         body1b: TextStyle = this.body1b,
         body1sb: TextStyle = this.body1sb,
         body1m: TextStyle = this.body1m,
@@ -83,8 +87,9 @@ class SpoonyTypography(
 
     ): SpoonyTypography = SpoonyTypography(
         title1,
-        title2b,
-        title2sb,
+        title2,
+        title3b,
+        title3sb,
         body1b,
         body1sb,
         body1m,
@@ -99,8 +104,9 @@ class SpoonyTypography(
 
     fun update(other: SpoonyTypography) {
         title1 = other.title1
-        title2b = other.title2b
-        title2sb = other.title2sb
+        title2 = other.title2
+        title3b = other.title3b
+        title3sb = other.title3sb
         body1b = other.body1b
         body1sb = other.body1sb
         body1m = other.body1m
@@ -135,13 +141,17 @@ fun SpoonyTypography(): SpoonyTypography {
     return SpoonyTypography(
         title1 = SpoonyTextStyle(
             fontFamily = PretendardBold,
+            fontSize = 24.sp
+        ),
+        title2 = SpoonyTextStyle(
+            fontFamily = PretendardBold,
             fontSize = 20.sp
         ),
-        title2b = SpoonyTextStyle(
+        title3b = SpoonyTextStyle(
             fontFamily = PretendardBold,
             fontSize = 18.sp
         ),
-        title2sb = SpoonyTextStyle(
+        title3sb = SpoonyTextStyle(
             fontFamily = PretendardSemiBold,
             fontSize = 18.sp
         ),
@@ -199,11 +209,15 @@ fun SpoonyTypographyPreview() {
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title2b
+                style = SpoonyAndroidTheme.typography.title2
             )
             Text(
                 "SpoonyAndroidTheme",
-                style = SpoonyAndroidTheme.typography.title2sb
+                style = SpoonyAndroidTheme.typography.title3b
+            )
+            Text(
+                "SpoonyAndroidTheme",
+                style = SpoonyAndroidTheme.typography.title3sb
             )
             Text(
                 "SpoonyAndroidTheme",

--- a/app/src/main/java/com/spoony/spoony/presentation/explore/component/ExploreTopAppBar.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/explore/component/ExploreTopAppBar.kt
@@ -35,7 +35,7 @@ fun ExploreTopAppBar(
         ) {
             Text(
                 text = "서울특별시 $place",
-                style = SpoonyAndroidTheme.typography.title2sb,
+                style = SpoonyAndroidTheme.typography.title3sb,
                 color = SpoonyAndroidTheme.colors.black
             )
             Icon(

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/PlaceDetailRoute.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/PlaceDetailRoute.kt
@@ -273,7 +273,7 @@ private fun PlaceDetailScreen(
 
             Text(
                 text = title,
-                style = SpoonyAndroidTheme.typography.title1,
+                style = SpoonyAndroidTheme.typography.title2,
                 color = SpoonyAndroidTheme.colors.black
             )
 

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/StoreInfo.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/StoreInfo.kt
@@ -97,7 +97,7 @@ fun StoreInfo(
         ) {
             Text(
                 locationSubTitle,
-                style = SpoonyAndroidTheme.typography.title2sb
+                style = SpoonyAndroidTheme.typography.title3sb
             )
             Spacer(modifier = Modifier.height(11.dp))
             PlaceDetailIconText(

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/StoreInfoItem.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/StoreInfoItem.kt
@@ -101,7 +101,7 @@ private fun StoreInfoItemLocationPreview() {
             content = {
                 Text(
                     "어키",
-                    style = SpoonyAndroidTheme.typography.title2sb
+                    style = SpoonyAndroidTheme.typography.title3sb
                 )
                 Spacer(modifier = Modifier.height(11.dp))
                 Column(

--- a/app/src/main/java/com/spoony/spoony/presentation/register/RegisterStepOneScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/register/RegisterStepOneScreen.kt
@@ -85,7 +85,7 @@ fun RegisterStepOneScreen(
     ) {
         Text(
             text = "나의 찐맛집을 등록해볼까요?",
-            style = SpoonyAndroidTheme.typography.title2b,
+            style = SpoonyAndroidTheme.typography.title3b,
             color = SpoonyAndroidTheme.colors.black
         )
 

--- a/app/src/main/java/com/spoony/spoony/presentation/register/RegisterStepTwoScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/register/RegisterStepTwoScreen.kt
@@ -70,7 +70,7 @@ fun RegisterStepTwoScreen(
     ) {
         Text(
             text = "거의 다 왔어요!",
-            style = SpoonyAndroidTheme.typography.title2b,
+            style = SpoonyAndroidTheme.typography.title3b,
             color = SpoonyAndroidTheme.colors.black
         )
 


### PR DESCRIPTION
## Related issue 🛠
- closed #234 

## Work Description ✏️
- `title2b`와 `title2sb` 스타일을 `title3b`와 `title3sb`로 변경하여 전반적인 타이포그래피 조정.
- `title1` 스타일을 `title2`로 변경.
- `RegisterStepOneScreen`, `ExploreTopAppBar`, `StoreInfoItem`, `StoreInfo`, `RegisterStepTwoScreen`, `PlaceDetailRoute`, `CloseTopAppBar`, `TitleTopAppBar`에서 변경된 타이포그래피 스타일을 적용.
-  하는김에 `UrlImage` 컴포저블에 프리뷰 기능을 추가.

## Screenshot 📸
![image](https://github.com/user-attachments/assets/b5dedded-ea5a-46e0-aba5-1b5225e0c28d)

## To Reviewers 📢
감사합니다