### PR TITLE
[FEAT/#239] 스플래시, 약관동의 내부 로직 구현

### DIFF
--- a/app/src/main/java/com/spoony/spoony/data/datasource/local/TokenDataSource.kt
+++ b/app/src/main/java/com/spoony/spoony/data/datasource/local/TokenDataSource.kt
@@ -1,0 +1,11 @@
+package com.spoony.spoony.data.datasource.local
+
+import kotlinx.coroutines.flow.Flow
+
+interface TokenDataSource {
+    suspend fun getAccessToken(): Flow<String>
+    suspend fun getRefreshToken(): Flow<String>
+    suspend fun updateAccessToken(accessToken: String)
+    suspend fun updateRefreshToken(refreshToken: String)
+    suspend fun clearTokens()
+}

--- a/app/src/main/java/com/spoony/spoony/data/datasourceimpl/local/TokenDataSourceImpl.kt
+++ b/app/src/main/java/com/spoony/spoony/data/datasourceimpl/local/TokenDataSourceImpl.kt
@@ -1,0 +1,44 @@
+package com.spoony.spoony.data.datasourceimpl.local
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.spoony.spoony.data.datasource.local.TokenDataSource
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class TokenDataSourceImpl @Inject constructor(
+    private val datastore: DataStore<Preferences>
+) : TokenDataSource {
+    override suspend fun getAccessToken(): Flow<String> = datastore.data
+        .map { preferences -> preferences[ACCESS_TOKEN] ?: "" }
+
+    override suspend fun getRefreshToken(): Flow<String> = datastore.data
+        .map { preferences -> preferences[REFRESH_TOKEN] ?: "" }
+
+    override suspend fun updateAccessToken(accessToken: String) {
+        datastore.edit { preferences ->
+            preferences[ACCESS_TOKEN] = accessToken
+        }
+    }
+
+    override suspend fun updateRefreshToken(refreshToken: String) {
+        datastore.edit { preferences ->
+            preferences[REFRESH_TOKEN] = refreshToken
+        }
+    }
+
+    override suspend fun clearTokens() {
+        datastore.edit { preferences ->
+            preferences[ACCESS_TOKEN] = ""
+            preferences[REFRESH_TOKEN] = ""
+        }
+    }
+
+    companion object {
+        private val ACCESS_TOKEN = stringPreferencesKey("ACCESS_TOKEN")
+        private val REFRESH_TOKEN = stringPreferencesKey("REFRESH_TOKEN")
+    }
+}

--- a/app/src/main/java/com/spoony/spoony/data/di/TokenDataStoreModule.kt
+++ b/app/src/main/java/com/spoony/spoony/data/di/TokenDataStoreModule.kt
@@ -1,0 +1,40 @@
+package com.spoony.spoony.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.spoony.spoony.data.datasource.local.TokenDataSource
+import com.spoony.spoony.data.datasourceimpl.local.TokenDataSourceImpl
+import com.spoony.spoony.data.repositoryimpl.TokenRepositoryImpl
+import com.spoony.spoony.domain.repository.TokenRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+private val Context.tokenDataStore: DataStore<Preferences> by preferencesDataStore(name = "token_preferences")
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TokenDataStoreModule {
+    @Provides
+    @Singleton
+    fun provideTokenDataStore(
+        @ApplicationContext context: Context
+    ): DataStore<Preferences> = context.tokenDataStore
+
+    @Provides
+    @Singleton
+    fun provideTokenDataSource(
+        dataStore: DataStore<Preferences>
+    ): TokenDataSource = TokenDataSourceImpl(dataStore)
+
+    @Provides
+    @Singleton
+    fun provideTokenRepository(
+        dataSource: TokenDataSource
+    ): TokenRepository = TokenRepositoryImpl(dataSource)
+}

--- a/app/src/main/java/com/spoony/spoony/data/di/TokenDataStoreModule.kt
+++ b/app/src/main/java/com/spoony/spoony/data/di/TokenDataStoreModule.kt
@@ -15,7 +15,8 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
-private val Context.tokenDataStore: DataStore<Preferences> by preferencesDataStore(name = "token_preferences")
+private const val TOKEN_PREFERENCES = "token_preferences"
+private val Context.tokenDataStore: DataStore<Preferences> by preferencesDataStore(name = TOKEN_PREFERENCES)
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/com/spoony/spoony/data/repositoryimpl/TokenRepositoryImpl.kt
+++ b/app/src/main/java/com/spoony/spoony/data/repositoryimpl/TokenRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.spoony.spoony.data.repositoryimpl
+
+import com.spoony.spoony.data.datasource.local.TokenDataSource
+import com.spoony.spoony.domain.repository.TokenRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+
+class TokenRepositoryImpl @Inject constructor(
+    private val tokenDataSource: TokenDataSource
+) : TokenRepository {
+    override suspend fun getAccessToken(): Flow<String> = tokenDataSource.getAccessToken()
+
+    override suspend fun getRefreshToken(): Flow<String> = tokenDataSource.getRefreshToken()
+
+    override suspend fun updateAccessToken(accessToken: String) = tokenDataSource.updateAccessToken(accessToken)
+
+    override suspend fun updateRefreshToken(refreshToken: String) = tokenDataSource.updateRefreshToken(refreshToken)
+
+    override suspend fun clearTokens() = tokenDataSource.clearTokens()
+}

--- a/app/src/main/java/com/spoony/spoony/domain/repository/TokenRepository.kt
+++ b/app/src/main/java/com/spoony/spoony/domain/repository/TokenRepository.kt
@@ -1,0 +1,11 @@
+package com.spoony.spoony.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface TokenRepository {
+    suspend fun getAccessToken(): Flow<String>
+    suspend fun getRefreshToken(): Flow<String>
+    suspend fun updateAccessToken(accessToken: String)
+    suspend fun updateRefreshToken(refreshToken: String)
+    suspend fun clearTokens()
+}

--- a/app/src/main/java/com/spoony/spoony/presentation/auth/termsofservice/TermsOfServiceScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/auth/termsofservice/TermsOfServiceScreen.kt
@@ -1,7 +1,6 @@
 package com.spoony.spoony.presentation.auth.termsofservice
 
 import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -16,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.spoony.spoony.core.designsystem.component.button.SpoonyButton
 import com.spoony.spoony.core.designsystem.theme.white
@@ -27,35 +27,30 @@ import kotlinx.collections.immutable.persistentListOf
 
 private data class SpoonyTerms(
     val title: String,
-    val link: String,
-    val isRequired: Boolean,
-    val isUnderlined: Boolean
+    val link: String?,
+    val isRequired: Boolean
 )
 
 private val termsList = persistentListOf(
     SpoonyTerms(
         title = "만 14세 이상입니다.",
         link = "https://github.com/Hyobeen-Park",
-        isRequired = true,
-        isUnderlined = false
+        isRequired = true
     ),
     SpoonyTerms(
         title = "스푸니 서비스 이용약관",
         link = "https://github.com/angryPodo",
-        isRequired = true,
-        isUnderlined = true
+        isRequired = true
     ),
     SpoonyTerms(
         title = "개인정보 처리방침",
         link = "https://github.com/Roel4990",
-        isRequired = true,
-        isUnderlined = true
+        isRequired = true
     ),
     SpoonyTerms(
         title = "위치기반 서비스 이용약관",
         link = "https://github.com/chattymin",
-        isRequired = true,
-        isUnderlined = true
+        isRequired = true
     )
 )
 
@@ -119,15 +114,15 @@ private fun TermsOfServiceScreen(
                         isChecked[index] = !isChecked[index]
                     },
                     onTitleClick = {
-                        if (link.isNotBlank()) {
-                            Intent(Intent.ACTION_VIEW, Uri.parse(link)).apply {
+                        if (link?.isNotBlank() == true) {
+                            Intent(Intent.ACTION_VIEW, link.toUri()).apply {
                                 context.startActivity(this)
                             }
                         }
                     },
                     isRequired = isRequired,
                     isChecked = isChecked[index],
-                    isUnderlined = isUnderlined,
+                    isUnderlined = link?.isNotBlank() == true,
                     modifier = Modifier
                         .padding(bottom = 16.dp)
                 )

--- a/app/src/main/java/com/spoony/spoony/presentation/main/MainNavigator.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/main/MainNavigator.kt
@@ -76,7 +76,13 @@ class MainNavigator(
         navController.navigateToSignIn(navOptions = navOptions)
     }
 
-    fun navigateToTermsOfService(navOptions: NavOptions? = null) {
+    fun navigateToTermsOfService(
+        navOptions: NavOptions? = navOptions {
+            popUpTo(NAVIGATION_ROOT) {
+                inclusive = true
+            }
+        }
+    ) {
         navController.navigateToTermsOfService(navOptions = navOptions)
     }
 

--- a/app/src/main/java/com/spoony/spoony/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/splash/SplashScreen.kt
@@ -16,14 +16,10 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.lifecycleScope
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.spoony.spoony.R
 import com.spoony.spoony.core.designsystem.theme.SpoonyAndroidTheme
 import com.spoony.spoony.core.designsystem.theme.main400
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 @Composable
 fun SplashRoute(
@@ -32,20 +28,16 @@ fun SplashRoute(
     viewModel: SplashViewModel = hiltViewModel()
 ) {
     val systemUiController = rememberSystemUiController()
-    val lifecycleOwner = LocalLifecycleOwner.current
 
     LaunchedEffect(Unit) {
         systemUiController.setNavigationBarColor(
             color = main400
         )
 
-        lifecycleOwner.lifecycleScope.launch {
-            delay(300)
-            if (viewModel.hasAccessToken()) {
-                navigateToMap()
-            } else {
-                navigateToSignIn()
-            }
+        if (viewModel.hasAccessToken()) {
+            navigateToMap()
+        } else {
+            navigateToSignIn()
         }
     }
 

--- a/app/src/main/java/com/spoony/spoony/presentation/splash/SplashScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/splash/SplashScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
@@ -27,7 +28,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun SplashRoute(
     navigateToMap: () -> Unit,
-    navigateToSignIn: () -> Unit
+    navigateToSignIn: () -> Unit,
+    viewModel: SplashViewModel = hiltViewModel()
 ) {
     val systemUiController = rememberSystemUiController()
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -38,8 +40,12 @@ fun SplashRoute(
         )
 
         lifecycleOwner.lifecycleScope.launch {
-            delay(1000)
-            navigateToSignIn()
+            delay(300)
+            if (viewModel.hasAccessToken()) {
+                navigateToMap()
+            } else {
+                navigateToSignIn()
+            }
         }
     }
 

--- a/app/src/main/java/com/spoony/spoony/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/splash/SplashViewModel.kt
@@ -1,0 +1,14 @@
+package com.spoony.spoony.presentation.splash
+
+import androidx.lifecycle.ViewModel
+import com.spoony.spoony.domain.repository.TokenRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.first
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(
+    private val tokenRepository: TokenRepository
+) : ViewModel() {
+    suspend fun hasAccessToken(): Boolean = tokenRepository.getAccessToken().first().isNotBlank()
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #239 

## Work Description ✏️
- 토큰 dataStore 구현
- 스플래시에서 토큰 저장 여부 확인
- 약관동의 확인 + 웹 연결 구현

## Screenshot 📸
https://github.com/user-attachments/assets/01807d10-ed93-47af-8fa2-3f312fefbb46

## Uncompleted Tasks 😅
로그인 서버 연결 해야해요...

## To Reviewers 📢
약관동의에서 뒤로가면 앱 꺼지는걸로 수정했습니다! 영상 녹화,,, 다시 안해도 되죠ㅎㅎㅎㅎ
그리고 dataStore 만들면서 local이랑 remote랑 구분을 해두는게 어떨까 싶어서 local패키지를 만들어봤어요! 다들 뭐가 더 좋은지 의견이 궁금합니다ㅎㅎ

오늘의 TMI: 민재오빠 리드미 바꿈