### PR TITLE
[FIX/#352] api 31 버전 이하는 화면 전체가 블러처리 되도록 수정

### DIFF
--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/DisappointItem.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/DisappointItem.kt
@@ -1,5 +1,8 @@
 package com.spoony.spoony.presentation.placeDetail.component
 
+import android.graphics.BlurMaskFilter
+import android.os.Build
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,6 +16,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
@@ -70,6 +75,23 @@ fun DisappointItem(
                         end = 12.dp
                     )
             )
+            if (isBlurred && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                Canvas(modifier = Modifier.matchParentSize()) {
+                    drawIntoCanvas { canvas ->
+                        val paint = android.graphics.Paint().apply {
+                            color = android.graphics.Color.LTGRAY
+                            maskFilter = BlurMaskFilter(30f, BlurMaskFilter.Blur.NORMAL)
+                        }
+                        canvas.nativeCanvas.drawRect(
+                            0f,
+                            0f,
+                            size.width,
+                            size.height,
+                            paint
+                        )
+                    }
+                }
+            }
             if (isBlurred) {
                 Box(
                     modifier = Modifier


### PR DESCRIPTION
## Related issue 🛠
- closed #352

## Work Description ✏️
- 캔버스로 버전 이하는 전체 블러처리되도록 우선 수정,, 추후 확장자로 리팩을 하는건 어떨지 싶습니다.

## Screenshot 📸
# API 31 미만
<img width="360" alt="image" src="https://github.com/user-attachments/assets/dc4d7cb4-e18d-4a2c-832e-eeb1bb31dc90" />

# API 31 이상
<img width="360" alt="image" src="https://github.com/user-attachments/assets/7cf6e316-a518-4624-9612-01ba4608dbe9" />


## To Reviewers 📢
추후 확장자로 리팩하도록 해주세요,, 그래도 다 수정하고 올리고싶긴함,,