### PR TITLE
[FEAT/#385] 토큰 재발급 에러 핸들러 구현

### DIFF
--- a/app/src/main/java/com/spoony/spoony/core/network/AuthenticatorErrorHandler.kt
+++ b/app/src/main/java/com/spoony/spoony/core/network/AuthenticatorErrorHandler.kt
@@ -1,0 +1,6 @@
+package com.spoony.spoony.core.network
+
+interface AuthenticatorErrorHandler {
+    fun handleTokenNullError()
+    suspend fun handleTokenReissueError()
+}

--- a/app/src/main/java/com/spoony/spoony/core/network/AuthenticatorErrorHandler.kt
+++ b/app/src/main/java/com/spoony/spoony/core/network/AuthenticatorErrorHandler.kt
@@ -1,6 +1,6 @@
 package com.spoony.spoony.core.network
 
 interface AuthenticatorErrorHandler {
-    fun handleTokenNullError()
+    suspend fun handleTokenNullError()
     suspend fun handleTokenReissueError()
 }

--- a/app/src/main/java/com/spoony/spoony/core/network/AuthenticatorErrorHandlerImpl.kt
+++ b/app/src/main/java/com/spoony/spoony/core/network/AuthenticatorErrorHandlerImpl.kt
@@ -1,0 +1,36 @@
+package com.spoony.spoony.core.network
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.widget.Toast
+import com.jakewharton.processphoenix.ProcessPhoenix
+import com.spoony.spoony.domain.repository.TokenRepository
+import javax.inject.Inject
+
+class AuthenticatorErrorHandlerImpl @Inject constructor(
+    private val context: Context,
+    private val tokenRepository: TokenRepository
+) : AuthenticatorErrorHandler {
+    private val handler = Handler(Looper.getMainLooper())
+
+    override fun handleTokenNullError() {
+        restartApp(RETRY_SIGN_IN)
+    }
+
+    override suspend fun handleTokenReissueError() {
+        tokenRepository.clearTokens()
+        restartApp(RETRY_SIGN_IN)
+    }
+
+    private fun restartApp(message: String) {
+        handler.post {
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            ProcessPhoenix.triggerRebirth(context)
+        }
+    }
+
+    private companion object {
+        const val RETRY_SIGN_IN = "재로그인이 필요합니다"
+    }
+}

--- a/app/src/main/java/com/spoony/spoony/core/network/AuthenticatorErrorHandlerImpl.kt
+++ b/app/src/main/java/com/spoony/spoony/core/network/AuthenticatorErrorHandlerImpl.kt
@@ -6,15 +6,17 @@ import android.os.Looper
 import android.widget.Toast
 import com.jakewharton.processphoenix.ProcessPhoenix
 import com.spoony.spoony.domain.repository.TokenRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class AuthenticatorErrorHandlerImpl @Inject constructor(
-    private val context: Context,
+    @ApplicationContext private val context: Context,
     private val tokenRepository: TokenRepository
 ) : AuthenticatorErrorHandler {
-    private val handler = Handler(Looper.getMainLooper())
+    private val handler by lazy { Handler(Looper.getMainLooper()) }
 
-    override fun handleTokenNullError() {
+    override suspend fun handleTokenNullError() {
+        tokenRepository.clearTokens()
         restartApp(RETRY_SIGN_IN)
     }
 

--- a/app/src/main/java/com/spoony/spoony/core/network/di/ErrorHandlerModule.kt
+++ b/app/src/main/java/com/spoony/spoony/core/network/di/ErrorHandlerModule.kt
@@ -1,23 +1,17 @@
 package com.spoony.spoony.core.network.di
 
-import android.content.Context
 import com.spoony.spoony.core.network.AuthenticatorErrorHandler
 import com.spoony.spoony.core.network.AuthenticatorErrorHandlerImpl
-import com.spoony.spoony.domain.repository.TokenRepository
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object ErrorHandlerModule {
-    @Provides
+abstract class ErrorHandlerModule {
+    @Binds
     @Singleton
-    fun provideAuthenticatorErrorHandler(
-        @ApplicationContext context: Context,
-        tokenRepository: TokenRepository
-    ): AuthenticatorErrorHandler = AuthenticatorErrorHandlerImpl(context, tokenRepository)
+    abstract fun provideAuthenticatorErrorHandler(authenticatorErrorHandlerImpl: AuthenticatorErrorHandlerImpl): AuthenticatorErrorHandler
 }

--- a/app/src/main/java/com/spoony/spoony/core/network/di/ErrorHandlerModule.kt
+++ b/app/src/main/java/com/spoony/spoony/core/network/di/ErrorHandlerModule.kt
@@ -1,0 +1,23 @@
+package com.spoony.spoony.core.network.di
+
+import android.content.Context
+import com.spoony.spoony.core.network.AuthenticatorErrorHandler
+import com.spoony.spoony.core.network.AuthenticatorErrorHandlerImpl
+import com.spoony.spoony.domain.repository.TokenRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ErrorHandlerModule {
+    @Provides
+    @Singleton
+    fun provideAuthenticatorErrorHandler(
+        @ApplicationContext context: Context,
+        tokenRepository: TokenRepository
+    ): AuthenticatorErrorHandler = AuthenticatorErrorHandlerImpl(context, tokenRepository)
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #385

## Work Description ✏️
- 토큰 재발급 에러 핸들러 구현

## Screenshot 📸
https://github.com/user-attachments/assets/ecea7bc4-e8ab-4e88-ad4f-0dcbd539caa6


## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
오로지 테스트코드만을 위한 에러 핸들러...ㅋㅋㅋ
어떤가요?? 토스트랑 스낵바 겹치는거 조금 신경쓰이긴 하는데,, 토스트 없이 바로 앱 재시작 시키는게 나으려나요?!??